### PR TITLE
chore: fix clippy lints on stable

### DIFF
--- a/src/checks/util.rs
+++ b/src/checks/util.rs
@@ -2,11 +2,7 @@ pub(super) fn rebuild_name(orig: &str, index: usize, replace: usize, replacement
     format!(
         "{before}{replacement}{after}",
         before = &orig[0..index],
-        after = if let Some(after) = orig.get(index + replace..) {
-            after
-        } else {
-            ""
-        }
+        after = orig.get(index + replace..).unwrap_or_default()
     )
 }
 

--- a/src/checks/version.rs
+++ b/src/checks/version.rs
@@ -12,7 +12,7 @@ impl Check for Version {
         package: &dyn Package,
     ) -> crate::Result<Vec<Squat>> {
         let trimmed = name
-            .trim_end_matches(&['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'])
+            .trim_end_matches(['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'])
             .trim_end_matches('-');
 
         Ok(


### PR DESCRIPTION
Newer stable clippy flags two lints that weren't caught when this code was written:

`manual_unwrap_or_default` in `util::rebuild_name` and `needless_borrows_for_generic_args` in `Version::check`.

No behaviour change. Both replacements are fine on MSRV 1.56.1 (`[char; N]` has implemented `Pattern` since 1.51).