### PR TITLE
Use `config:best-practices` Renovate preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:best-practices"
   ]
 }


### PR DESCRIPTION
Enables lockfile maintenance and dev-dependency pinning, neither of which is included in `config:recommended`. This was meant to happen in #12 but somehow my change got overwritten.